### PR TITLE
Allow identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 /.idea
+/**/wip

--- a/function-timer/Cargo.toml
+++ b/function-timer/Cargo.toml
@@ -20,6 +20,12 @@ name = "test_time_function"
 [[test]]
 name = "test_time_struct"
 
+[[test]]
+name = "test_time_ident"
+
+[[test]]
+name = "test_time_fail"
+
 [dependencies]
 function-timer-macro = { version = "0.2", path = "../function-timer-macro"}
 metrics = "0.20"

--- a/function-timer/tests/fail/fail.rs
+++ b/function-timer/tests/fail/fail.rs
@@ -1,0 +1,8 @@
+use function_timer::time;
+
+struct Test {}
+
+impl Test {
+    #[time(struct)]
+    fn test() {}
+}

--- a/function-timer/tests/fail/fail.stderr
+++ b/function-timer/tests/fail/fail.stderr
@@ -1,0 +1,11 @@
+error: Expected literal or identifier
+ --> tests/fail/fail.rs:6:12
+  |
+6 |     #[time(struct)]
+  |            ^^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/fail/fail.rs:8:2
+  |
+8 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/fail/fail.rs`

--- a/function-timer/tests/test_time_fail.rs
+++ b/function-timer/tests/test_time_fail.rs
@@ -1,0 +1,5 @@
+#[test]
+fn test_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/fail/fail.rs");
+}

--- a/function-timer/tests/test_time_function.rs
+++ b/function-timer/tests/test_time_function.rs
@@ -1,9 +1,9 @@
-use std::error::Error;
-use std::time::Duration;
-use metrics::Label;
 use function_timer::time;
+use metrics::Label;
 use metrics_util::debugging::{DebugValue, Snapshotter};
 use metrics_util::MetricKind;
+use std::error::Error;
+use std::time::Duration;
 
 struct Test {}
 
@@ -19,9 +19,9 @@ impl Test {
     }
 
     #[time("another_metric")]
-    pub fn impl_fail_function(&self, text:&str) -> Result<(), Box<dyn Error>>{
+    pub fn impl_fail_function(&self, text: &str) -> Result<(), Box<dyn Error>> {
         std::thread::sleep(Duration::from_secs(2));
-        let number:usize = text.parse()?;
+        let number: usize = text.parse()?;
         println!("{number}");
 
         Ok(())
@@ -34,9 +34,8 @@ pub fn free_function() {
 }
 
 #[test]
-fn test_time_free_function() -> Result<(), Box<dyn Error>>{
-    let _ = metrics_util::debugging::DebuggingRecorder::per_thread()
-        .install();
+fn test_time_free_function() -> Result<(), Box<dyn Error>> {
+    let _ = metrics_util::debugging::DebuggingRecorder::per_thread().install();
 
     free_function();
 
@@ -57,9 +56,8 @@ fn test_time_free_function() -> Result<(), Box<dyn Error>>{
 }
 
 #[test]
-fn test_time_static_function() -> Result<(), Box<dyn Error>>{
-    let _ = metrics_util::debugging::DebuggingRecorder::per_thread()
-        .install();
+fn test_time_static_function() -> Result<(), Box<dyn Error>> {
+    let _ = metrics_util::debugging::DebuggingRecorder::per_thread().install();
 
     Test::static_function();
 
@@ -80,11 +78,10 @@ fn test_time_static_function() -> Result<(), Box<dyn Error>>{
 }
 
 #[test]
-fn test_time_impl_function() -> Result<(), Box<dyn Error>>{
-    let _ = metrics_util::debugging::DebuggingRecorder::per_thread()
-        .install();
+fn test_time_impl_function() -> Result<(), Box<dyn Error>> {
+    let _ = metrics_util::debugging::DebuggingRecorder::per_thread().install();
 
-    let t = Test{};
+    let t = Test {};
     t.impl_function();
 
     let snapshot = Snapshotter::current_thread_snapshot();
@@ -98,18 +95,16 @@ fn test_time_impl_function() -> Result<(), Box<dyn Error>>{
         assert_eq!(name.as_str(), "my_metric");
         assert_eq!(labels, vec![Label::new("function", "impl_function")]);
         assert!(matches!(debug_value, DebugValue::Histogram(_)));
-
     }
 
     Ok(())
 }
 
 #[test]
-fn test_time_impl_fail_function() -> Result<(), Box<dyn Error>>{
-    let _ = metrics_util::debugging::DebuggingRecorder::per_thread()
-        .install();
+fn test_time_impl_fail_function() -> Result<(), Box<dyn Error>> {
+    let _ = metrics_util::debugging::DebuggingRecorder::per_thread().install();
 
-    let t = Test{};
+    let t = Test {};
     let _ = t.impl_fail_function("azerty");
 
     let snapshot = Snapshotter::current_thread_snapshot();
@@ -123,7 +118,6 @@ fn test_time_impl_fail_function() -> Result<(), Box<dyn Error>>{
         assert_eq!(name.as_str(), "another_metric");
         assert_eq!(labels, vec![Label::new("function", "impl_fail_function")]);
         assert!(matches!(debug_value, DebugValue::Histogram(_)));
-
     }
 
     Ok(())

--- a/function-timer/tests/test_time_ident.rs
+++ b/function-timer/tests/test_time_ident.rs
@@ -1,0 +1,68 @@
+use function_timer::time;
+use metrics::Label;
+use metrics_util::debugging::{DebugValue, Snapshotter};
+use metrics_util::MetricKind;
+use std::error::Error;
+
+static METRIC_NAME: &str = "my_metric";
+const OTHER_METRIC_NAME: &str = "other_metric";
+
+struct Test {}
+
+impl Test {
+    #[time(METRIC_NAME)]
+    fn test1(&self) {
+        println!("test");
+    }
+
+    #[time(OTHER_METRIC_NAME)]
+    fn test2(&self) {
+        println!("test2");
+    }
+}
+
+#[test]
+fn test_ident_static() -> Result<(), Box<dyn Error>> {
+    let _ = metrics_util::debugging::DebuggingRecorder::per_thread().install();
+
+    let t = Test {};
+    t.test1();
+
+    let snapshot = Snapshotter::current_thread_snapshot();
+    assert!(snapshot.is_some(), "No snapshot");
+    let metrics = snapshot.unwrap().into_vec();
+
+    for (key, _, _, debug_value) in metrics {
+        let (kind, key) = key.into_parts();
+        let (name, labels) = key.into_parts();
+        assert_eq!(kind, MetricKind::Histogram);
+        assert_eq!(name.as_str(), "my_metric");
+        assert_eq!(labels, vec![Label::new("function", "test1")]);
+        assert!(matches!(debug_value, DebugValue::Histogram(_)));
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_ident_const() -> Result<(), Box<dyn Error>> {
+    let _ = metrics_util::debugging::DebuggingRecorder::per_thread().install();
+
+    let t = Test {};
+    t.test2();
+
+    let snapshot = Snapshotter::current_thread_snapshot();
+    assert!(snapshot.is_some(), "No snapshot");
+    let metrics = snapshot.unwrap().into_vec();
+
+    for (key, _, _, debug_value) in metrics {
+        let (kind, key) = key.into_parts();
+        let (name, labels) = key.into_parts();
+        assert_eq!(kind, MetricKind::Histogram);
+        assert_eq!(name.as_str(), "other_metric");
+        assert_eq!(labels, vec![Label::new("function", "test2")]);
+        assert!(matches!(debug_value, DebugValue::Histogram(_)));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Allow identifiers such as `static NAME:&str = "name"` or `const NAME:&str = "name"`.

Closes #3